### PR TITLE
Add new Digest API, BLAKE2 algorithm(s)

### DIFF
--- a/Data/ContentStore/Config.hs
+++ b/Data/ContentStore/Config.hs
@@ -32,14 +32,14 @@ data Config = Config {
 
 instance FromJSON Config where
     parseJSON = withObject "Config" $ \v ->
-        Config <$> v .:? "hash" .!= "SHA256"
+        Config <$> v .:? "hash" .!= "BLAKE2b256"
 
 instance ToJSON Config where
     toJSON Config{..} = object [ "hash" .= toJSON confHash ]
 
 defaultConfig :: Config
 defaultConfig =
-    Config { confHash = "SHA256" }
+    Config { confHash = "BLAKE2b256" }
 
 readConfig :: FilePath -> IO (Either T.Text Config)
 readConfig path = do

--- a/Data/ContentStore/Digest.hs
+++ b/Data/ContentStore/Digest.hs
@@ -1,38 +1,113 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE ExistentialQuantification #-}
 
-module Data.ContentStore.Digest(ObjectDigest(..),
-                                hashByteString,
-                                hashLazyByteString)
+module Data.ContentStore.Digest(DigestAlgorithm,
+                                getDigestAlgorithm,
+                                digestName,
+                                digestSize,
+                                digestInit,
+                                DigestContext,
+                                digestUpdate,
+                                digestUpdates,
+                                digestFinalize,
+                                digestByteString,
+                                digestLazyByteString,
+                                ObjectDigest,
+                                toHex,
+                                fromByteString)
  where
 
-import           Crypto.Hash(Digest, hash, hashlazy)
-import           Crypto.Hash.Algorithms(SHA256, SHA512)
+import           Crypto.Hash
+import           Data.ByteArray(Bytes, ByteArrayAccess, convert)
+import           Data.ByteArray.Encoding(Base(..), convertToBase)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Text as T
+import           Data.Text.Encoding(decodeUtf8)
 
--- Only a subset of the algorithms provided by cryptonite are supported
--- by our content store.  You can't have everything.  Because each
--- algorithm is implemented as a different type (though, all are
--- members of the HashAlgorithm typeclass), we need to wrap them up into
--- a single data type if we are to write generic hashing functions.  And
--- we want to do that to prevent the spread of knowing which algorithm
--- is in use throughout the code.
-data ObjectDigest = ObjectSHA256 (Digest SHA256)
-                  | ObjectSHA512 (Digest SHA512)
+-- cryptonite is about 50% too clever with its types, if you ask me.
+-- Here's simpler ones that we can use in ContentStore.
+
+--
+-- DIGEST TYPES
+--
+
+-- | A DigestAlgorithm represents one specific hash algorithm.
+data DigestAlgorithm = forall a. (HashAlgorithm a, Show a) => DigestAlgorithm a
+
+-- | Holds the context for a given instance of a DigestAlgorithm.
+data DigestContext = forall a. HashAlgorithm a => DigestContext (Context a)
+
+-- ObjectDigest is the (binary) representation of a digest.
+newtype ObjectDigest = ObjectDigest Bytes
+    deriving (Eq, Ord, ByteArrayAccess)
 
 instance Show ObjectDigest where
-    show (ObjectSHA256 d) = show d
-    show (ObjectSHA512 d) = show d
+    show (ObjectDigest b) = show b
 
-hashByteString :: T.Text -> BS.ByteString -> Maybe ObjectDigest
-hashByteString algo bs = case algo of
-    "SHA256" -> Just $ ObjectSHA256 (hash bs :: Digest SHA256)
-    "SHA512" -> Just $ ObjectSHA512 (hash bs :: Digest SHA512)
-    _        -> Nothing
+--
+-- PRIVATE FUNCTIONS
+--
 
-hashLazyByteString :: T.Text -> LBS.ByteString -> Maybe ObjectDigest
-hashLazyByteString algo lbs = case algo of
-    "SHA256" -> Just $ ObjectSHA256 (hashlazy lbs :: Digest SHA256)
-    "SHA512" -> Just $ ObjectSHA512 (hashlazy lbs :: Digest SHA512)
-    _        -> Nothing
+fromDigest :: HashAlgorithm a => Digest a -> ObjectDigest
+fromDigest = ObjectDigest . convert
+
+hashLazyWith :: HashAlgorithm a => a -> LBS.ByteString -> Digest a
+hashLazyWith _ = hashlazy
+
+--
+-- PUBLIC FUNCTIONS
+--
+
+-- | Get the name of this DigestAlgorithm
+digestName :: DigestAlgorithm -> String
+digestName (DigestAlgorithm a) = show a
+
+-- | The size of the ObjectDigest returned by this DigestAlgorithm
+digestSize :: DigestAlgorithm -> Int
+digestSize (DigestAlgorithm a) = hashDigestSize a
+
+-- | Initialize a new DigestContext for this DigestAlgorithm
+digestInit :: DigestAlgorithm -> DigestContext
+digestInit (DigestAlgorithm a) = DigestContext $ hashInitWith a
+
+-- | Update the DigestContext with one ByteString/Bytes/etc item
+digestUpdate :: ByteArrayAccess ba => DigestContext -> ba -> DigestContext
+digestUpdate (DigestContext ctx) = DigestContext . hashUpdate ctx
+
+-- | Update the DigestContext with many ByteString/Bytes/etc. items
+digestUpdates :: ByteArrayAccess ba => DigestContext -> [ba] -> DigestContext
+digestUpdates (DigestContext ctx) = DigestContext . hashUpdates ctx
+
+-- | Finish the digest, returning an ObjectDigest
+digestFinalize :: DigestContext -> ObjectDigest
+digestFinalize (DigestContext ctx) = fromDigest $ hashFinalize ctx
+
+-- | Hash a ByteString into an ObjectDigest
+digestByteString :: DigestAlgorithm -> BS.ByteString -> ObjectDigest
+digestByteString (DigestAlgorithm a) = fromDigest . hashWith a
+
+-- | Hash a lazy ByteString into an ObjectDigest
+digestLazyByteString :: DigestAlgorithm -> LBS.ByteString -> ObjectDigest
+digestLazyByteString (DigestAlgorithm a) = fromDigest . hashLazyWith a
+
+-- | Check and convert a ByteString into an ObjectDigest
+fromByteString :: ByteArrayAccess ba => DigestAlgorithm -> ba -> Maybe ObjectDigest
+fromByteString (DigestAlgorithm a) = fmap fromDigest . digestFromByteStringWith a
+-- helper for above
+digestFromByteStringWith :: (HashAlgorithm a, ByteArrayAccess ba) => a -> ba -> Maybe (Digest a)
+digestFromByteStringWith _ = digestFromByteString
+
+-- | Convert an ObjectDigest to its hex representation
+-- TODO: probably more efficient if we can just coerce the converted Bytes..
+toHex :: ObjectDigest -> String
+toHex = T.unpack . decodeUtf8 . convertToBase Base16
+
+
+-- | Given the Text name of a digest algorithm, return a DigestAlgorithm
+-- | (or Nothing if we don't recognize the DigestAlgorithm's name).
+getDigestAlgorithm :: T.Text -> Maybe DigestAlgorithm
+getDigestAlgorithm "SHA256"     = Just $ DigestAlgorithm SHA256
+getDigestAlgorithm "SHA512"     = Just $ DigestAlgorithm SHA512
+getDigestAlgorithm _            = Nothing

--- a/Data/ContentStore/Digest.hs
+++ b/Data/ContentStore/Digest.hs
@@ -110,4 +110,10 @@ toHex = T.unpack . decodeUtf8 . convertToBase Base16
 getDigestAlgorithm :: T.Text -> Maybe DigestAlgorithm
 getDigestAlgorithm "SHA256"     = Just $ DigestAlgorithm SHA256
 getDigestAlgorithm "SHA512"     = Just $ DigestAlgorithm SHA512
+getDigestAlgorithm "BLAKE2"     = Just $ DigestAlgorithm Blake2b_512
+getDigestAlgorithm "BLAKE2b"    = Just $ DigestAlgorithm Blake2b_512
+getDigestAlgorithm "BLAKE2b512" = Just $ DigestAlgorithm Blake2b_512
+getDigestAlgorithm "BLAKE2b256" = Just $ DigestAlgorithm Blake2b_256
+getDigestAlgorithm "BLAKE2s"    = Just $ DigestAlgorithm Blake2s_256
+getDigestAlgorithm "BLAKE2s256" = Just $ DigestAlgorithm Blake2s_256
 getDigestAlgorithm _            = Nothing

--- a/content-store.cabal
+++ b/content-store.cabal
@@ -3,6 +3,7 @@ version:             0.1.0
 license:             LGPL
 author:              Chris Lumens
 maintainer:          clumens@redhat.com
+copyright:           (c) 2017 Red Hat, Inc
 build-type:          Simple
 cabal-version:       >= 1.10
 
@@ -23,6 +24,7 @@ library
                      filepath,
                      htoml,
                      monad-control,
+                     memory >= 0.14.3,
                      mtl,
                      resourcet,
                      text,
@@ -31,3 +33,16 @@ library
 
   default-language:  Haskell2010
   ghc-options:       -Wall
+
+test-suite spec
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  hs-source-dirs: tests
+  build-depends:    base == 4.*,
+                    bytestring,
+                    hspec == 2.*,
+                    memory >= 0.14.3,
+                    content-store
+
+  default-language: Haskell2010
+  ghc-options: -Wall

--- a/content-store.cabal
+++ b/content-store.cabal
@@ -19,7 +19,7 @@ library
                      conduit >= 1.0.11,
                      conduit-combinators,
                      conduit-extra >= 1.1.0,
-                     cryptonite,
+                     cryptonite >= 0.22,
                      directory,
                      filepath,
                      htoml,

--- a/tests/Data/ContentStore/DigestSpec.hs
+++ b/tests/Data/ContentStore/DigestSpec.hs
@@ -1,0 +1,52 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Data.ContentStore.DigestSpec(spec) where
+
+import Test.Hspec
+import Data.Maybe(fromJust)
+import Data.ContentStore.Digest
+import qualified Data.ByteString as B
+import qualified Data.ByteArray as BA
+
+testInput :: B.ByteString
+testInput = "The Dude abides."
+
+testSHA256Digest :: B.ByteString
+testSHA256Digest = "\xcd\x9c\xf3\x08\x62\x61\x24\xa7\x81\x81\xc0\x22\xfb\x9d\x0d\x51\x1a\xf1\xc1\x5d\x32\x20\x12\xf0\xa6\x9d\xfe\x86\x40\xc3\x40\xaa"
+
+testSHA256Hex :: String
+testSHA256Hex = "cd9cf308626124a78181c022fb9d0d511af1c15d322012f0a69dfe8640c340aa"
+
+spec :: Spec
+spec = do
+    describe "Digest.DigestAlgorithm" $ do
+        it "knows about SHA256" $
+            digestName <$> getDigestAlgorithm "SHA256" `shouldBe` Just "SHA256"
+
+        let daSHA256 = fromJust $ getDigestAlgorithm "SHA256"
+        it "has the correct size for SHA256" $
+            digestSize daSHA256 `shouldBe` 32
+
+        let od = digestByteString daSHA256 testInput
+        let hex = toHex od
+
+        it "does SHA256 correctly" $
+            BA.convert od `shouldBe` testSHA256Digest
+
+        it "converts ObjectDigest to hex" $
+            hex `shouldBe` testSHA256Hex
+
+    describe "Digest.DigestContext" $ do
+        let da = fromJust $ getDigestAlgorithm "SHA256"
+        let ctx = digestInit da
+        it "can do digests piece by piece" $ do
+            let hex = toHex $ digestFinalize $ digestUpdate ctx testInput
+            hex `shouldBe` testSHA256Hex
+
+    describe "fromByteString" $ do
+        let da = fromJust $ getDigestAlgorithm "SHA256"
+        let od = digestByteString da testInput
+        it "accepts a 32-byte ByteString" $
+            fromByteString da testSHA256Digest `shouldBe` Just od
+        it "rejects wrong-sized ByteString" $
+            fromByteString da (B.take 20 testSHA256Digest) `shouldBe` Nothing

--- a/tests/Data/ContentStoreSpec.hs
+++ b/tests/Data/ContentStoreSpec.hs
@@ -1,0 +1,10 @@
+module Data.ContentStoreSpec(spec) where
+
+import Test.Hspec
+import Data.ContentStore
+
+spec :: Spec
+spec =
+    describe "ContentStore" $
+        it "has dummy test" $
+            () `shouldBe` ()

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}


### PR DESCRIPTION
These commits rework the Digest API so it's a little easier to use and more flexible. 

The first commit reworks the Digest API and adds support for doing digests chunk by chunk (like in a lazy conduit / pipeline), also adding a test suite to ensure things are working as expected.

It also makes ContentStore use ObjectDigest wherever possible internally, because probably we shouldn't be operating on String versions of digests except when necessary (i.e. in filenames and when displaying things to the user).

The second commit adds the BLAKE2 family of digest algorithms. BLAKE was a finalist for SHA3, so it should be at least as secure as SHA1/SHA2, but it's faster than both (up to 2x as fast as SHA256, in fact). See https://blake2.net/ for more info.

The last commit makes BLAKE2b256 the default digest algorithm for ContentStore, which _seems_ like the right tradeoff of speed and security. This might be a premature optimization, though, so it might be worth further discussion/consideration/benchmarking before making that change.